### PR TITLE
Update default export

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -17,8 +17,9 @@ node_modules
 # Optional npm cache directory
 .npm
 
-# tests
+# tests & examples
 /test
+/examples
 
 # IDE
 .idea
@@ -28,3 +29,4 @@ Makefile
 .eslintrc.yml
 .gitignore
 .changelogrc
+.prettierrc

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+printWidth:     140
+semi:           false
+tabWidth:       4
+singleQuote:    true
+bracketSpacing: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: node_js
 node_js:
-  - '8'
-  - '10'
-  - '11'
+- '8'
+- '10'
+- '11'
 script:
-  - yarn run lint
-  - yarn run check-fmt
-  - yarn run tsc
-  - yarn run test-cover
+- yarn run lint
+- yarn run check-fmt
+- yarn run tsc
+- yarn run test-cover
 after_success:
-  - yarn run coverage
+- yarn run coverage
 notifications:
-  flowdock: $FLOWDOCK_API_TOKEN
+  slack:
+    secure: vuBp7KKQqHax5B/9NS7D8GiedcpLPXrfe7gzsyDow89rcqv6O6dtePzF1QtujsCVExRYNhApgCSb+cA30aHaJih6sQ9F3/suPSa1ql1AbpNmpxuQFFGO2LiRIHQ5cFMiBpvr4vP/nK3emwdRukKNmVgVcikYUCmJhrEXaL2YvCWq2amZj8pe/r2PCaeHknG2hVsJGhEHIxAwGqBtQQGI+z65MWebSAdLnmdPAoGDYfHRMKyhkFrF0BDsrCFOWRp/AoZ4rr6oqTZ7h97wTRKTNXoVcBoFp2dvXOuA3xuWrQvGFAIWdgkUwRHrN0ALuGy6/vZLhGldcKgvhQtEXCXeBCb/JQ15MjaUaxtcpUxkcZ/kHObqe1XXdbZbhGImkdg4ea7IH4H0pCzRyGieBbH63Mb0Pu46UCqAmCjjeKYPsSa3dOPXBHc48AP/zS1QrBxYeH7GwHmQZN4L39g2POWLu5Td0FfIIiDB/Y9ryE87mRkLFE0IGpFT+DlWGII1L75kgs673DFwbyuOGSoBUKdEV6TcGEmE4ExitBQwjwfDiZLY1ouL1WlTbcj84X9ou4idlCxBGScaaR/E4ddwEMH8C8C/QMRlpDQLyRJYH6PP1S7T8XCr7LHvLxaMn0C8TcRaXo0m8UdSy3kcWvAUCvgVXAngTZE1fzRELN4IaELwwfY=

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A Lightweight logger that combines debug namespacing capabilities with winston l
     - [Using namespaces](#using-namespaces)
     - [Outputs](#outputs)
     - [Metadata](#metadata)
+- [TypeScript](#typescript)
 
 ## Installation
 
@@ -295,6 +296,10 @@ logger.warn('message', { someData: 'someValue' })
 output: 
 
 ![Example](docs/images/example_context.gif)
+
+## TypeScript
+
+This package provides its own definition, so it can be easily used with TypeScript.
 
 [npm-image]: https://img.shields.io/npm/v/@ekino/logger.svg?style=flat-square
 [npm-url]: https://www.npmjs.com/package/@ekino/logger

--- a/README.md
+++ b/README.md
@@ -43,29 +43,32 @@ Log level can be set by calling `setLevel` function.
 
 For example, enabling `info` will enable `info`, `warn` and `error` but not `debug` or `trace`.
 The "special" log level `none` means no log and can only be used to set a namespace level.
+
 ``` js
 { trace: 0, debug: 1, info: 2, warn: 3, error: 4 }
 ```
 
-The basic log function signature is
+The basic log function signature is:
+
 ```js
 my_log.the_level(message, data) // With data an object holding informations usefull for debug purpose
 ```
 
 Example
 
-``` javascript
-    const logger = require('@ekino/logger')
+```js
+const { setNamespaces, setLevel, createLogger } = require('@ekino/logger')
 
-    logger.setNamespaces('root:*')
-    logger.setLevel('debug')
+setNamespaces('root:*')
+setLevel('debug')
 
-    const log = logger('root:testing')
-    log.debug('sample message', {
-        foo: 'bar',
-    })
+const logger = createLogger('root:testing')
+logger.debug('sample message', {
+    foo: 'bar',
+})
 ```
-output : 
+
+output: 
 
 ![Example](docs/images/example_usage1.gif)
 
@@ -75,25 +78,27 @@ One of the main complexity working with node is ability to follow all logs attac
 This is not mandatory, but based on our experience, we recommend as a best practice to add a unique identifier that will be passed all along functions calls.
 When you log something, you can provide this id as a first parameter and logger will log it. If not provided, it's auto generated.
 
-The signature of the function with contextId is : 
+The signature of the function with contextId is: 
+
 ```js
-    my_log.the_level(contextId, message, data)
+my_log.the_level(contextId, message, data)
 ```
 
 Example app.js
 
 ``` javascript
-    const logger = require('@ekino/logger')
-    
-    logger.setNamespaces('root:*')
-    logger.setLevel('debug')
-    
-    const log = logger('root:testing')
-    log.debug('ctxId', 'log with predefined context ID', {
-        foo: 'bar',
-    })
+const { setNamespaces, setLevel, createLogger } = require('@ekino/logger')
+
+setNamespaces('root:*')
+setLevel('debug')
+
+const logger = createLogger('root:testing')
+logger.debug('ctxId', 'log with predefined context ID', {
+    foo: 'bar',
+})
 ```
-output : 
+
+output: 
 
 ![Example](docs/images/example_usage2.gif)
 
@@ -111,38 +116,41 @@ A namespace ':*' means eveything after ':' will be enabled. Namespaces are parse
 
 To define namespace level, you should suffix namespace with "=the_level" 
 For example let's say you need to enable all info logs but for debug purpose you need to lower the level 
-of the namespace database to `debug`. You could then use : 
+of the namespace database to `debug`. You could then use: 
 
-``` javascript
-    const logger = require('@ekino/logger')
-    
-    logger.setLevel('info')
-    logger.setNamespaces('*,database*=debug,database:redis*=none')
+```js
+const { setLevel, setNamespaces } = require('@ekino/logger')
+
+setLevel('info')
+setNamespaces('*,database*=debug,database:redis*=none')
 ```
+
 #### Using Logging Namespaces
 
-``` js
-    const logger = require('@ekino/logger')
+```js
+const { setNamespaces, setLevel, createLogger } = require('@ekino/logger')
 
-    logger.setNamespaces('namespace:*, namespace:mute=none');
-    logger.setLevel('debug');
-  
-    const log = logger('namespace:subNamespace');
-    const log2 = logger('namespace:mute');
-    log.debug("Will be logged");
-    log2.info("Will not be logged");
+setNamespaces('namespace:*, namespace:mute=none')
+setLevel('debug')
+
+const loggerA = createLogger('namespace:subNamespace')
+const loggerB = createLogger('namespace:mute')
+
+loggerA.debug('Will be logged')
+loggerB.info('Will not be logged')
 ```
 
-``` js
-    const logger = require('@ekino/logger')
+```js
+const { setNamespaces, setLevel, createLogger } = require('@ekino/logger')
 
-    logger.setNamespaces('*, wrongNamespace=none');
-    logger.setLevel('debug');
-    
-    const log = logger('namespace:subNamespace');
-    const log2 = logger('wrongNamespace');
-    log.debug("Will be logged");
-    log2.info("Will not be logged");
+setNamespaces('*, wrongNamespace=none')
+setLevel('debug')
+
+const loggerA = createLogger('namespace:subNamespace')
+const loggerB = createLogger('wrongNamespace')
+
+loggerA.debug('Will be logged')
+loggerB.info('Will not be logged')
 ```
 
 ### Outputs
@@ -154,17 +162,21 @@ You can use multiple adapters at the same time
 
 #### JSON
 
-``` js
-    const logger = require('@ekino/logger')
-      
-    logger.setNamespaces('namespace:*');
-    logger.setLevel('debug');
-    logger.setOutput(logger.outputs.json);
-      
-    const log = logger('namespace:subNamespace');
-    log.debug('ctxId', 'Will be logged',{someData: 'someValue', someData2: 'someValue'});
+```js
+const { setNamespaces, setLevel, setOutput, outputs, createLogger } = require('@ekino/logger')
+
+setNamespaces('namespace:*')
+setLevel('debug')
+setOutput(outputs.json)
+
+const logger = createLogger('namespace:subNamespace')
+logger.debug('ctxId', 'Will be logged', {
+    someData: 'someValue',
+    someData2: 'someValue'
+})
 ```
-output : 
+
+output: 
 
 ![Example](docs/images/example_usage3.gif)
 
@@ -172,24 +184,30 @@ output :
 
 Pretty will output a yaml like content.
 
-``` js
-    const logger = require('@ekino/logger')
-      
-    logger.setNamespaces('namespace:*');
-    logger.setLevel('debug');
-    logger.setOutput(logger.outputs.pretty);
-   
-    const log = logger('namespace:subNamespace');
-    log.debug('ctxId', 'Will be logged',{someData: 'someValue', someData2: 'someValue'});
+```js
+const { setNamespaces, setLevel, setOutput, outputs, createLogger } = require('@ekino/logger')
+    
+setNamespaces('namespace:*')
+setLevel('debug')
+setOutput(outputs.pretty)
+
+const logger = createLogger('namespace:subNamespace')
+logger.debug('ctxId', 'Will be logged', {
+    someData: 'someValue',
+    someData2: 'someValue'
+})
 ```
-output : 
+
+output: 
 
 ![Example](docs/images/example_pretty.gif)
 
 #### Output function
+
 An output, is a function that will receive log data and should transform and store it
 
-Log data follow the format : 
+Log data follow the format: 
+
 ```
 {
     time: Date,
@@ -202,54 +220,58 @@ Log data follow the format :
 }
 ```
 
-``` js
-   const logger = require('@ekino/logger')
-      
-   logger.setNamespaces('namespace:*');
-   logger.setLevel('debug');
-   
-   function consoleAdapter(log) {
-      console.log(logger.outputUtils.stringify(log))
-   }
- 
-   // This will output in stdout with the pretty output 
-   // and in the same will log through native console.log() function (usually to stdout too)
-   logger.setOutput([logger.output.pretty, consoleAdapter]);
- 
-   const log = logger('namespace:subNamespace');
-   log.debug('ctxId', 'Will be logged',{someData: 'someValue', someData2: 'someValue'});
+```js
+const { setNamespaces, setLevel, setOutput, outputs, outputUtils, createLogger } = require('@ekino/logger')
+    
+setNamespaces('namespace:*')
+setLevel('debug')
+
+const consoleAdapter = (log) => {
+    console.log(outputUtils.stringify(log))
+}
+
+// This will output in stdout with the pretty output 
+// and in the same will log through native console.log() function (usually to stdout too)
+setOutput([outputs.pretty, consoleAdapter])
+
+const logger = createLogger('namespace:subNamespace')
+logger.debug('ctxId', 'Will be logged', {
+    someData: 'someValue',
+    someData2: 'someValue'
+})
 ```
 
 #### JSON Stringify utility
+
 To ease the creation of an output adapter, we provide a utility to stringify a json object that support circular reference
 and add stack to output for errors.
 
-``` js
-   const logger = require('@ekino/logger')
+```js
+const { outputUtils } = require('@ekino/logger')
 
-   function consoleAdapter(log) {
-      console.log(logger.outputUtils.stringify(log))
-   }
+const consoleAdapter = (log) => {
+    console.log(outputUtils.stringify(log))
+}
 ```
+
 ### Log data
 
 Most of the time, a log message is not enough to guess context.
 You can append arbitrary data to your logs. 
 If you're using some kind of log collector, you'll then be able to extract those values and inject them in elasticsearch for example.
 
-``` js
-    const logger = require('@ekino/logger')
-      
-    logger.setOutput('pretty');
-    logger.setNamespaces('namespace:*');
-    logger.setLevel('info');
+```js
+const { setOutput, setNamespaces, setLevel, createLogger } = require('@ekino/logger')
     
-    const log = logger('namespace:subNamespace');
-    
-    log.warn('message', { someData: 'someValue' });
+setOutput('pretty')
+setNamespaces('namespace:*')
+setLevel('info')
+
+const logger = createLogger('namespace:subNamespace')
+logger.warn('message', { someData: 'someValue' })
 ```
 
-output : 
+output: 
 
 ![Example](docs/images/example_data.gif)
 
@@ -259,19 +281,18 @@ Sometimes, you need to identify to which version or which application the logs r
 To do so, we provide a function to set informations that will be added to the each log at a top level key.
 
 ```js
-    const logger = require('@ekino/logger')
-    
-    logger.setOutput('pretty');
-    logger.setNamespaces('*');
-    logger.setLevel('info');
-    logger.setGlobalContext({ version: '2.0.0', env: 'dev' });
-    
-    const log = logger('namespace');
-    
-    log.warn('message', { someData: 'someValue' });
+const { setOutput, setNamespaces, setLevel, setGlobalContext, createLogger } = require('@ekino/logger')
+
+setOutput('pretty')
+setNamespaces('*')
+setLevel('info')
+setGlobalContext({ version: '2.0.0', env: 'dev' })
+
+const logger = createLogger('namespace')
+logger.warn('message', { someData: 'someValue' })
 ```
 
-output : 
+output: 
 
 ![Example](docs/images/example_context.gif)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,8 @@
 // Type definitions for @ekino/logger
 // Project: https://github.com/ekino/node-logger
 
-export = logger
-
-declare function logger(namespace: string): logger.Logger
-
 declare namespace logger {
+    export function createLogger(namespace?: string): Logger
     export function setNamespaces(namespace: string): void
     export function setLevel(level: LogLevel): void
     export function setOutput(adapter: OutputAdapter): void

--- a/index.js
+++ b/index.js
@@ -54,11 +54,11 @@ const internals = {}
 
 /************* EXPORTS *************/
 /**
- * @typedef {Function} Logger
- * @param {String} namespace
+ * @typedef {Function} createLogger
+ * @param {String} [namespace]
  * @return {Logger}
  */
-module.exports = function(namespace) {
+module.exports.createLogger = function(namespace) {
     namespace = namespace || ''
 
     let logger = internals.loggers[namespace]

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "typescript": "3.x"
   },
   "scripts": {
-    "fmt": "prettier --print-width 140 --tab-width=4 --single-quote --bracket-spacing --no-semi --color --write \"{.,{test}/**/}/*.{js,ts}\"",
-    "check-fmt": "prettier --print-width 140 --tab-width=4 --single-quote --bracket-spacing --no-semi --list-different \"{.,{test}/**/}/*.{js,ts}\"",
+    "fmt": "prettier --color --write \"{.,{test}/**/}/*.{js,ts}\"",
+    "check-fmt": "prettier --list-different \"{.,{test}/**/}/*.{js,ts}\"",
     "tsc": "tsc",
     "test": "ava",
     "test-cover": "nyc ava",

--- a/test/logger.js
+++ b/test/logger.js
@@ -11,7 +11,7 @@ test.beforeEach(t => {
 })
 
 test('A logger instance should have levels function and isLevelEnabled function', t => {
-    const log = logger()
+    const log = logger.createLogger()
     t.is(typeof log.trace, 'function')
     t.is(typeof log.debug, 'function')
     t.is(typeof log.info, 'function')
@@ -41,7 +41,7 @@ test('A logger instance should log if level and namespace are enabled', t => {
     logger.setNamespaces('*')
     logger.setLevel('info')
 
-    const log = logger()
+    const log = logger.createLogger()
     const spy = sinon.spy(logger.internals, 'write')
 
     log.info(null)
@@ -54,7 +54,7 @@ test("A logger instance shouldn't log if level is lower than enabled level", t =
     logger.setNamespaces('*')
     logger.setLevel('info')
 
-    const log = logger()
+    const log = logger.createLogger()
     const spy = sinon.spy(logger.internals, 'write')
 
     log.debug(null, 'test')
@@ -69,7 +69,7 @@ test("A logger instance shouldn't log if namespace is not enabled", t => {
 
     logger.setLevel('info')
 
-    const log = logger('default')
+    const log = logger.createLogger('default')
     const spy = sinon.spy(logger.internals, 'write')
 
     log.info(null, 'test')
@@ -84,7 +84,7 @@ test("A logger instance shouldn't log if log level is lower than namespace patte
 
     logger.setLevel('info')
 
-    const log = logger('test:subtest')
+    const log = logger.createLogger('test:subtest')
     const spy = sinon.spy(logger.internals, 'write')
 
     log.info(null, 'test')
@@ -99,7 +99,7 @@ test("A logger instance should log if log level is higher or equal than namespac
 
     logger.setLevel('info')
 
-    const log = logger('test:subtest')
+    const log = logger.createLogger('test:subtest')
     const spy = sinon.spy(logger.internals, 'write')
 
     log.debug(null)
@@ -113,8 +113,8 @@ test("A logger instance should log according to state defined in the latest matc
 
     logger.setLevel('info')
 
-    const log = logger('test:subtest')
-    const log2 = logger('test2:subtest')
+    const log = logger.createLogger('test:subtest')
+    const log2 = logger.createLogger('test2:subtest')
     const spy = sinon.spy(logger.internals, 'write')
 
     log.warn(null)
@@ -133,7 +133,7 @@ test('A logger should call an output adapter with log data, metadata, message an
 
     const now = new Date()
 
-    const log = logger('test:subTest')
+    const log = logger.createLogger('test:subTest')
     const timersStub = sinon.useFakeTimers(now.getTime())
 
     log.warn('ctxId', 'test', { someData: 'someValue' })
@@ -163,7 +163,7 @@ test('A logger should call all output output adapters added', t => {
 
     const now = new Date()
 
-    const log = logger('test:subTest')
+    const log = logger.createLogger('test:subTest')
     const timersStub = sinon.useFakeTimers(now.getTime())
 
     log.warn('ctxId', 'test', { someData: 'someValue' })
@@ -197,7 +197,7 @@ test('A logger shoudn\'t throw an error if not outputs defined', t => {
 
     logger.setOutput()
 
-    const log = logger('test:subTest')
+    const log = logger.createLogger('test:subTest')
 
     log.warn('ctxId', 'test', { someData: 'someValue' })
     t.true(true)
@@ -213,7 +213,7 @@ test('A logger should support defining a global context', t => {
 
     const now = new Date()
 
-    const log = logger('test:global:context')
+    const log = logger.createLogger('test:global:context')
     const timersStub = sinon.useFakeTimers(now.getTime())
 
     log.warn('ctxId', 'test')
@@ -242,7 +242,7 @@ test('A logger contextId arg should be an an optional argument', t => {
 
     const now = new Date()
 
-    const log = logger('ns1:subns1')
+    const log = logger.createLogger('ns1:subns1')
     const timersStub = sinon.useFakeTimers(now.getTime())
 
     log.warn('msg1', { key1: 'value1' })
@@ -264,7 +264,7 @@ test("A logger should not log if it's namespace is disabled after call to setNam
     logger.setNamespaces('*')
     logger.setLevel('info')
 
-    const log = logger('ns1')
+    const log = logger.createLogger('ns1')
     const spy = sinon.spy(logger.internals, 'write')
 
     log.info(null, 'msg1')
@@ -281,7 +281,7 @@ test('A logger should not log if log level is not upper after call to setLevel',
     logger.setNamespaces('*')
     logger.setLevel('info')
 
-    const log = logger('ns1')
+    const log = logger.createLogger('ns1')
     const spy = sinon.spy(logger.internals, 'write')
 
     log.info(null, 'msg1')
@@ -298,7 +298,7 @@ test('A logger should not log if upper namespace was enabled, but sub namespace 
     logger.setNamespaces('ns1:*,ns1:subns1=none')
     logger.setLevel('info')
 
-    const log = logger('ns1:subns1')
+    const log = logger.createLogger('ns1:subns1')
     const spy = sinon.spy(logger.internals, 'write')
 
     log.info(null, 'msg1')
@@ -312,7 +312,7 @@ test('A logger should return true for a call to isLevelEnabled if level and name
     logger.setNamespaces('ns1:*,ns1:subns1=none')
     logger.setLevel('info')
 
-    const log = logger('ns1:subns2')
+    const log = logger.createLogger('ns1:subns2')
     t.true(log.isLevelEnabled('warn'))
 })
 
@@ -320,7 +320,7 @@ test('A logger should return false for a call to isLevelEnabled if namespace lev
     logger.setNamespaces('ns1:*,ns1:subns1=none')
     logger.setLevel('info')
 
-    const log = logger('ns1:subns1')
+    const log = logger.createLogger('ns1:subns1')
     t.false(log.isLevelEnabled('warn'))
 })
 
@@ -328,7 +328,7 @@ test('A logger should return true for a call to isLevelEnabled if top namespace 
     logger.setNamespaces('ns1:*,ns1:subns1=none')
     logger.setLevel('error')
 
-    const log = logger('ns1:subns2')
+    const log = logger.createLogger('ns1:subns2')
     t.false(log.isLevelEnabled('warn'))
 })
 
@@ -336,8 +336,8 @@ test('loggers should be equal if they are for the same namespace', t => {
     logger.setNamespaces('ns1:*,ns1:subns1=none')
     logger.setLevel('error')
 
-    const log1 = logger('ns1:subns2')
-    const log2 = logger('ns1:subns2')
+    const log1 = logger.createLogger('ns1:subns2')
+    const log2 = logger.createLogger('ns1:subns2')
     t.is(log1, log2)
 })
 

--- a/test/output_adapters.js
+++ b/test/output_adapters.js
@@ -63,7 +63,7 @@ test('JSON Output Adpater should work if used by logger', t => {
     const spy = sinon.spy(process.stdout, 'write')
     const timersStub = sinon.useFakeTimers(now.getTime())
 
-    const log = logger('test:subTest')
+    const log = logger.createLogger('test:subTest')
     log.warn('ctxId', 'test', { someData: 'someValue' })
 
     t.true(spy.calledTwice)
@@ -126,7 +126,7 @@ test('pretty output adapter should work if used by logger', t => {
     const spy = sinon.spy(process.stdout, 'write')
     const timersStub = sinon.useFakeTimers(1547205226232)
 
-    const log = logger('test:subTest')
+    const log = logger.createLogger('test:subTest')
     log.warn('ctxId', 'test', { someData: 'someValue' })
 
     t.true(spy.calledTwice)


### PR DESCRIPTION
This PR replaces the default commonjs export with a named function to avoid naming collision and make the need to instantiate a logger more explicit.

current approach:

```javascript
import Logger from '@ekino/logger'

const logger = Logger('namespace')
```

new approach:

```javascript
import { createLogger } from '@ekino/logger'

const logger = createLogger('namespace')
```

It also includes other minor updates:
- use slack instead of flowdock for travis notifications
- use `.prettierrc` instead of cli args
- udpate documentation
- do not publish `examples/` to npm